### PR TITLE
Update pointer to node during walk

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -120,6 +120,15 @@ var AstNode = _.chain(types)
                     });
                 } else if (_.isObject(node) && !(node instanceof RegExp)) {
                     callback(node);
+                    // update the node reference in case the tree has been
+                    // changed by a call to wrap or replace in the callback
+                    if (node.parent) {
+                        if (node.parentArrayIndex === false) {
+                            node = node.parent.data[node.parentKey];
+                        } else {
+                            node = node.parent.data[node.parentKey][node.parentArrayIndex];
+                        }
+                    }
                     _.each(_.values(node.data), function(datum) {
                         _walk(datum, callback);
                     });

--- a/test/index.js
+++ b/test/index.js
@@ -115,8 +115,9 @@ module.exports = {
         test.equals(
             "1 + 2 + f(5)",
             astronaut("1 + 2 + 5").walk(function(node) {
-                if (node.isLiteral() && node.value() === 5) {
-                    node.wrap("f(<%= node %>)");
+                if (node.isLiteral() && node.value() === 5
+                 && !(node.parent.isCallExpression && node.parent.isCallExpression())) {
+                    node.wrap("f(<%= expression %>)");
                 }
                 return node;
             }).deparse()


### PR DESCRIPTION
While walking the tree, if a node is wrapped or replaced during the
`callback` it doesn't update the node being iterated on inside `walk`,
which means the rest of the walk callbacks are firing for elements no
longer in the main tree.  This resets the reference to the given node
during the walk phase after each callback executes.  This is a
fundimental departure, as it means implementations using walk that are
not read-only will have to always check to ensure that a given node has
not already been wrapped since nodes being wrapped get the callback fired
_twice_.  You can see this in the updated test, which without these
additional checks would result in a stack overflow.
