### PR TITLE
Fix parentArrayIndex updating

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -296,10 +296,15 @@ StatementTrait = _.extend({}, {
         var newNode = this.parseAndExtractCorrespondingNode(code),
             index = (prefix) ? this.parentArrayIndex : this.parentArrayIndex + 1;
 
+		newNode.parentArrayIndex = index;
+
         this.parent.data[this.parentKey] = this.parent.data[this.parentKey]
             .slice(0, index)
             .concat([newNode])
-            .concat(this.parent.data[this.parentKey].slice(index)); 
+            .concat(this.parent.data[this.parentKey].slice(index).map(function(node) {
+                ++node.parentArrayIndex;
+                return node;
+            }));
     },
     /**
      * Parse the code, and prepend this node with the result. 
@@ -493,7 +498,8 @@ var astronaut = function(codeOrNode) {
                     value: parentKey,
                 }, 
                 parentArrayIndex: {
-                    value: arrayIndex
+                    value: arrayIndex,
+                    writable: true
                 }
             } 
         );

--- a/test/index.js
+++ b/test/index.js
@@ -228,6 +228,16 @@ module.exports = {
             }).deparse(options)
         )
         test.done();
-    }
+    },
+    testParentArrayIndexCorrectness: function(test) {
+        var code = "var a = 1;\nvar b = 2;\nvar c = 3;";
+        var ast = astronaut(code);
 
+        ast.body()[1].prefix("var d = 4;");
+
+        for (var i = 0; i < ast.body().length; ++i) {
+            test.equals(i, ast.body()[i].parentArrayIndex)
+        }
+        test.done();
+    }
 };


### PR DESCRIPTION
Prefix/suffix insertion leaves parentArrayIndex in a bad state.
Therefore, next insertion will not be correct.

The problem looks like that:
We have an array of elements with corresponding `parentArrayIndex`es - [0,1,2,3...].
Then, when we trying to insert e.g. prefix for the first element, `parentArrayIndex`es start looking terrible - [0,0,1,2,3...]. But the following calls of the `affix` function will rely on correctness of these values. That's why `parentArrayIndex` should be `writable` and `affix` function should revise whole array on every call.

One additional check in the test shows the difference.
